### PR TITLE
Bug fixes for URLS and DOIs

### DIFF
--- a/app/search/dataone.py
+++ b/app/search/dataone.py
@@ -41,6 +41,10 @@ class SolrDirectSearch(SearcherBase):
         if contentUrl:
             urls.extend(contentUrl['value'])
 
+        doi = None
+        if 'seriesId' in result and result['seriesId'].startswith('doi:'):
+            doi = result['seriesId']
+
         return SearchResult(
                     # Because Blazegraph uses normalized query scores, we can approximate search
                     # ranking by normalizing these as well. However, this does nothing for the
@@ -54,7 +58,7 @@ class SolrDirectSearch(SearcherBase):
                     # westBoundCoord and southBoundCoord in this data source
                     # But there is also a named place available, which is what is being used here
                     spatial_coverage=result.pop('placeKey', None),
-                    doi=result.pop('seriesId', None),
+                    doi=doi,
                     keywords=result.pop('keywords', []),
                     origin=result.pop('origin', []),
                     # todo: temporal coverage

--- a/app/search/dataone.py
+++ b/app/search/dataone.py
@@ -30,6 +30,17 @@ class SolrDirectSearch(SearcherBase):
         return result_set
 
     def convert_result(self, result):
+        urls = []
+        dataUrl = result.pop('dataUrl', None)
+        if dataUrl:
+            urls.append(dataUrl)
+        webUrl = result.pop('webUrl', [])
+        if webUrl:
+            urls.extend(webUrl)
+        contentUrl = result.pop('contentUrl', None)
+        if contentUrl:
+            urls.extend(contentUrl['value'])
+
         return SearchResult(
                     # Because Blazegraph uses normalized query scores, we can approximate search
                     # ranking by normalizing these as well. However, this does nothing for the
@@ -43,10 +54,11 @@ class SolrDirectSearch(SearcherBase):
                     # westBoundCoord and southBoundCoord in this data source
                     # But there is also a named place available, which is what is being used here
                     spatial_coverage=result.pop('placeKey', None),
+                    doi=result.pop('seriesId', None),
                     keywords=result.pop('keywords', []),
                     origin=result.pop('origin', []),
                     # todo: temporal coverage
-                    urls=result.pop('webUrl', []), # todo: not sure if webUrl is the right thing to use here
+                    urls=urls,
                     source="DataONE"
                 )
 

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -82,6 +82,7 @@ class GleanerSearch(SearcherBase):
             result['urls'].append(url)
         if sameAs is not None:
             result['urls'].append(sameAs)
-        result['keywords'] = result['keywords'].split(',')
+        keywords = result.pop('keywords', '')
+        result['keywords'] = keywords.split(',')
         result['source'] = "Gleaner"
         return SearchResult(**result)

--- a/app/search/search.py
+++ b/app/search/search.py
@@ -29,7 +29,7 @@ class SearchResult:
         self.source = kwargs.pop('source', 'Anonymous')
 
         # If we have a DOI somewhere, use it as much as possible
-        if not self.doi and self.id.startswith('doi:'):
+        if not self.doi and self.id and self.id.startswith('doi:'):
             self.doi = self.id
 
         self.urls = list(set(self.urls))

--- a/app/search/search.py
+++ b/app/search/search.py
@@ -28,11 +28,15 @@ class SearchResult:
         # Good for debugging
         self.source = kwargs.pop('source', 'Anonymous')
 
-        # If we have a DOI somewhere, use it as much as possible
-        if not self.doi and self.id and self.id.startswith('doi:'):
-            self.doi = self.id
-
         self.urls = list(set(self.urls))
+
+        # If we have a DOI somewhere, use it as much as possible
+        if not self.doi:
+            if self.id and self.id.startswith('doi:'):
+                self.doi = self.id
+            elif any((match := url).startswith('http://dx.doi.org/') for url in self.urls):
+                self.doi = 'doi:' + match.lstrip('http://dx.doi.org/')
+
 
     """ Methods to make these sortable """
 

--- a/app/search/search.py
+++ b/app/search/search.py
@@ -30,11 +30,9 @@ class SearchResult:
 
         # If we have a DOI somewhere, use it as much as possible
         if not self.doi and self.id.startswith('doi:'):
-            self.doi = self.id.lstrip('doi:')
+            self.doi = self.id
 
-        if self.doi:
-            self.urls.append('http://doi.org/' + self.doi)
-            self.urls = list(set(self.urls))
+        self.urls = list(set(self.urls))
 
     """ Methods to make these sortable """
 

--- a/app/static/css/_search.scss
+++ b/app/static/css/_search.scss
@@ -24,6 +24,17 @@
     margin: 1rem 0;
 }
 
+.doi {
+    padding: 0.25rem;
+    text-align: right;
+}
+
+.doi__link {
+    text-decoration: none;
+    color: constants.$soft-black;
+    font-weight: constants.$font-weight-light;
+}
+
 .abstract {
     cursor: pointer;
 }

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -4,6 +4,13 @@
  <ul class="results">
  {% for result in result_set.results %}
   <li class="result" data-score={{ result.score }} data-source="{{ result.source }} data-id= {{ result.id }}">
+    {% if result.doi %}
+      <div class="doi">
+        <a href="http://doi.org/{{ result.doi }}" class="doi__link" target="_blank" rel="noopener">
+          {{ result.doi }}
+        </a>
+      </div>
+    {% endif %}
     <h3 class="result__title">{{ result.title }}</h3>
     <h4 class="result__keywords">
       {% for keyword in result.keywords %}

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -310,12 +310,12 @@ class TestSearchResult(unittest.TestCase):
 
     def test_doi_urls(self):
         test_obj = search.SearchResult(
-            id='doi:test_test', score=4, urls=['http://test1'])
+            id='doi:test_test', score=4, urls=['http://test1', 'http://dx.doi.org/test_test'])
         self.assertEqual(test_obj.id, 'doi:test_test')
         self.assertEqual(test_obj.doi, 'doi:test_test')
         test_obj.urls.sort()
         self.assertEqual(
-            test_obj.urls, ['http://test1'])
+            test_obj.urls, ['http://dx.doi.org/test_test', 'http://test1'])
 
         test_obj_2 = search.SearchResult(id='doi:test2_test2', score=4, urls=[
                                          'http://test1', 'http://doi.org/test2_test2'])
@@ -330,6 +330,14 @@ class TestSearchResult(unittest.TestCase):
         self.assertEqual(test_existing_doi.id, 'doi:test3')
         self.assertEqual(test_existing_doi.doi, 'existing_value')
         self.assertListEqual(test_existing_doi.urls, [])
+
+        test_doi_from_url = search.SearchResult(
+            id='foo', score=4, urls=['http://test1', 'http://dx.doi.org/asdf'])
+        self.assertEqual(test_doi_from_url.id, 'foo')
+        self.assertEqual(test_doi_from_url.doi, 'doi:asdf')
+        test_doi_from_url.urls.sort()
+        self.assertEqual(
+            test_doi_from_url.urls, ['http://dx.doi.org/asdf', 'http://test1'])
 
     def test_init_defaults(self):
         test_obj = search.SearchResult(id='test test test', score=10.5)

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -150,6 +150,7 @@ class TestGleanerSearch(unittest.TestCase):
             'id': {'type': 'literal', 'value': 'urn:uuid:696f9141-4e1a-5270-8c94-b0aabe0bbee7'}
         }
         result = self.search.convert_result(test_result)
+        result.urls.sort()
         self.assertIsInstance(result, search.SearchResult)
         self.assertEqual(result.urls, ['url1', 'url2'])
         self.assertEqual(result.source, "Gleaner")
@@ -238,6 +239,7 @@ class TestSearchResult(unittest.TestCase):
             'score': 42
         }
         test_obj = search.SearchResult(**kwargs_dict)
+        test_obj.urls.sort()
         self.assertEqual(test_obj.title, kwargs_dict['title'])
         self.assertEqual(test_obj.urls, kwargs_dict['urls'])
         self.assertEqual(test_obj.abstract, kwargs_dict['abstract'])
@@ -259,22 +261,22 @@ class TestSearchResult(unittest.TestCase):
     def test_init_doi(self):
         test_obj = search.SearchResult(id='doi:test_test', score=4)
         self.assertEqual(test_obj.id, 'doi:test_test')
-        self.assertEqual(test_obj.doi, 'test_test')
-        self.assertEqual(test_obj.urls, ['http://doi.org/test_test'])
+        self.assertEqual(test_obj.doi, 'doi:test_test')
+        self.assertEqual(test_obj.urls, [])
 
     def test_doi_urls(self):
         test_obj = search.SearchResult(
             id='doi:test_test', score=4, urls=['http://test1'])
         self.assertEqual(test_obj.id, 'doi:test_test')
-        self.assertEqual(test_obj.doi, 'test_test')
+        self.assertEqual(test_obj.doi, 'doi:test_test')
         test_obj.urls.sort()
         self.assertEqual(
-            test_obj.urls, ['http://doi.org/test_test', 'http://test1'])
+            test_obj.urls, ['http://test1'])
 
         test_obj_2 = search.SearchResult(id='doi:test2_test2', score=4, urls=[
                                          'http://test1', 'http://doi.org/test2_test2'])
         self.assertEqual(test_obj_2.id, 'doi:test2_test2')
-        self.assertEqual(test_obj_2.doi, 'test2_test2')
+        self.assertEqual(test_obj_2.doi, 'doi:test2_test2')
         test_obj_2.urls.sort()
         self.assertListEqual(
             test_obj_2.urls, ['http://doi.org/test2_test2', 'http://test1'])
@@ -283,8 +285,7 @@ class TestSearchResult(unittest.TestCase):
             id='doi:test3', score=1, doi='existing_value')
         self.assertEqual(test_existing_doi.id, 'doi:test3')
         self.assertEqual(test_existing_doi.doi, 'existing_value')
-        self.assertListEqual(test_existing_doi.urls, [
-            'http://doi.org/existing_value'])
+        self.assertListEqual(test_existing_doi.urls, [])
 
     def test_init_defaults(self):
         test_obj = search.SearchResult(id='test test test', score=10.5)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,7 +99,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: nein09/polder-federated-search:1.30.0
+    image: nein09/polder-federated-search:1.32.0
     depends_on:
       - triplestore
       - s3system

--- a/docker/gleaner.yaml
+++ b/docker/gleaner.yaml
@@ -40,13 +40,6 @@ sources:
   properName: U.S. Antarctic Program Data Center
   domain: https://www.usap-dc.org
   active: true
-- name: npdc
-  type: sitemap
-  headless: false
-  url: https://npdc.nl/sitemap/dataset.xml
-  properName:  Netherlands Polar Data Center
-  domain: https://npdc.nl
-  active: true
 - name: gem
   type: sitemap
   headless: true

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.30.0"
+appVersion: "1.32.0"

--- a/helm/templates/gleaner-config.yaml
+++ b/helm/templates/gleaner-config.yaml
@@ -47,13 +47,6 @@ data:
       properName: U.S. Antarctic Program Data Center
       domain: https://www.usap-dc.org
       active: true
-    - name: npdc
-      type: sitemap
-      headless: false
-      url: https://npdc.nl/sitemap/dataset.xml
-      properName:  Netherlands Polar Data Center
-      domain: https://npdc.nl
-      active: true
     - name: gem
       type: sitemap
       headless: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polder-federated-search",
-  "version": "1.30.0",
+  "version": "1.32.0",
   "description": "A starter for web apps using Flask and Parcel",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
- get and expose urls from more places in DataONE results (https://trello.com/c/oS4utan7)
- find and expose DOIs more prominently (https://trello.com/c/Cj3TbC3U)
- Remove NPDC from the list of Gleaner repositories to crawl, because it's already covered by DataONE