### PR TITLE
Center loading spinner on all screen sizes

### DIFF
--- a/app/static/css/_form.scss
+++ b/app/static/css/_form.scss
@@ -101,10 +101,11 @@
 
 
 .loading {
-    width: 00px; 
     margin: 0 auto;
     display: none;
     background-color: constants.$soft-white;
+    padding: 1rem;
+    text-align: center;
 }
 
 
@@ -115,7 +116,7 @@
   border-left: 4px solid #fff;
   border-radius: 50%;
   height: 50px;
-  margin-bottom: 10px;
+  margin: 0.5rem auto;
   width: 50px;
 }
 
@@ -123,8 +124,6 @@
   color: constants.$dark-blue;
   font-family: arial, sans-serif;
   font-weight: constants.$font-weight-bold;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .loader-text:after {


### PR DESCRIPTION
A quick change - after deploying the latest and greatest to https://search-dev.polder.info, I tried it on a few different screen widths, and noticed that the loading spinner was a bit off-center on phones. Letting the loading div set its own width instead of setting it to 0 and adding a couple styles to center the text allowed it to center itself on all sizes.