### PR TITLE
Add a DNS policy so this job knows how to get to the url we want to curl

### DIFF
--- a/helm/templates/crawl.yaml
+++ b/helm/templates/crawl.yaml
@@ -19,6 +19,17 @@ spec:
               name: gleaner-config
           - name: gleaner-context
             emptyDir: {}
+          dnsPolicy: None
+          dnsConfig:
+            nameservers:
+              - 10.96.0.10
+            searches:
+            - {{ .Release.Namespace }}.svc.cluster.local
+            - svc.cluster.local
+            - cluster.local
+            options:
+            - name: ndots
+              value: "5"
           initContainers:
           - name: get-contextfiles
             image: curlimages/curl:7.82.0


### PR DESCRIPTION
For https://trello.com/c/2gae85vy

I noticed today that the weekly 'crawl' job was failing on search-dev, and it was failing because it couldn't do `curl https://schema.org/version/latest/schemaorg-current-https.jsonld`.

The fix is to tell the job where it can find a DNS server. There's one specified in `gleaner-deployment.yaml`, so I must have just forgotten to put this in the crawl configuration too.