### PR TITLE
A better way to set up Sentry error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ That file will be structured like this:
       minioAccessKey: <your base64 encoded value here>
       minioSecretKey: <your base64 encoded value here>
       flaskSecretKey: <your base64 encoded value here>
+      sentryDsn: <your base64 encoded value here>
 ```
 You can see that the values of the secrets are base64 encoded - in order to do this, run ` echo -n 'mysecretkey' | base64` on your command line for each value, and paste the result in where the key goes. Don't check in your real secrets anywhere!
   You can read more about secrets [here](https://kubernetes.io/docs/concepts/configuration/secret/).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.40.4"
+appVersion: "1.40.5"

--- a/helm/templates/web-deployment.yaml
+++ b/helm/templates/web-deployment.yaml
@@ -55,7 +55,10 @@ spec:
         - name: FLASK_ENV
           value: production
         - name: SENTRY_DSN
-          value: {{ .Values.sentryDsn }}
+          valueFrom:
+            secretKeyRef:
+              key: sentryDsn
+              name: {{ .Release.Name }}-secrets
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.40.4",
+  "version": "1.40.5",
   "description": "A starter for web apps using Flask and Parcel",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
It gets the Sentry endpoint URL from a `secrets` file now, to make it easier to expose it to the Helm deployment.