### PR TITLE
Better error handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -80,7 +80,7 @@ def combined_search():
 
 @app.errorhandler(NotFound)
 def handle_404(e):
-    logger.debug("404 for url %s", request.url)
+    logger.error("404 for url %s", request.url)
     return render_template("404.html", e=e), 404
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,7 +2,7 @@ import logging
 from flask import redirect, render_template, request, url_for
 from datetime import date
 from sentry_sdk import capture_exception
-from werkzeug.exceptions import HTTPException
+from werkzeug.exceptions import HTTPException, NotFound
 
 from app import app
 from app.search.dataone import SolrDirectSearch
@@ -12,6 +12,7 @@ from app.search.search import SearchResultSet
 BAD_REQUEST_STATUS = 400
 
 logger = logging.getLogger('app')
+
 
 @app.route('/')
 def home():
@@ -77,9 +78,15 @@ def combined_search():
     return _do_combined_search('results.html', **request.args)
 
 
+@app.errorhandler(NotFound)
+def handle_404(e):
+    logger.debug("404 for url %s", request.url)
+    return render_template("404.html", e=e), 404
+
+
 @app.errorhandler(Exception)
 def handle_exception(e):
-    logger.debug("Exception in routes", e)
+    logger.error("Exception while handling request for %s: %s", request.url, e)
 
     # Record it in Sentry if we're in production
     if app.debug == False:

--- a/app/search/dataone.py
+++ b/app/search/dataone.py
@@ -26,7 +26,7 @@ class SolrDirectSearch(SearcherBase):
     @staticmethod
     def _build_text_search_query(text=None):
         if text:
-            return f"&q={text}"
+            return f"&q={quote(text)}"
         else:
             return ""
 

--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -118,7 +118,7 @@ class GleanerSearch(SearcherBase):
     def _build_text_search_query(text=None):
         if text:
             return f"""
-                ?lit bds:search "{text}" .
+                ?lit bds:search '''{text}''' .
                 ?lit bds:matchAllTerms "false" .
                 ?lit bds:relevance ?relevance .
                 ?s ?p ?lit .

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block title %}Not Found{% endblock %}
+
+{% block content %}
+    <div class="container error">
+        <h2>Sorry, that page doesn't exist.</h2>
+        <p>You may want to <a href="{{ url_for('home') }}" class="error__link">try again</a>.</p>
+        <p>If you'd like help with whatever happened, please <a href="mailto:ito-webdev1@oceannetworks.ca" class="error__link">email us</a>.</p>
+    </div>
+{% endblock %}

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -38,7 +38,6 @@ class TestGleanerSearch(unittest.TestCase):
         self.mock_query = Mock()
         self.mock_query.convert = mock_convert
 
-
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_text_search_none(self, query):
         query.return_value = self.mock_query
@@ -166,13 +165,13 @@ class TestGleanerSearch(unittest.TestCase):
             "FILTER(?end_date <= '2023-03-31'^^xsd:date)", self.search.query)
         self.assertIn("OFFSET 100", self.search.query)
 
-
     # gross, but requests-mock does not touch the requests
     # that SPARQLWrapper makes using good old urllib
     # for some reason, even if I try to capture
     # every request, so here we are creating fake file handles
     # because that's what the response object that
     # SPARQLWrapper knows how to work with expects
+
     @patch('SPARQLWrapper.Wrapper.urlopener')
     def test_search_error(self, urlopen):
         with patch("builtins.open", mock_open(read_data="some data")) as file_patch:
@@ -240,6 +239,7 @@ class TestGleanerSearch(unittest.TestCase):
         result = self.search.convert_result(test_result)
         result.urls.sort()
         self.assertIsInstance(result, search.SearchResult)
-        self.assertEqual(result.urls, ['http://www.mycooldataset.com', 'url1', 'url2'])
+        self.assertEqual(
+            result.urls, ['http://www.mycooldataset.com', 'url1', 'url2'])
         self.assertEqual(result.keywords, ['keyword1', 'keyword2', 'keyword3'])
         self.assertEqual(result.source, "Gleaner")

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -38,6 +38,7 @@ class TestGleanerSearch(unittest.TestCase):
         self.mock_query = Mock()
         self.mock_query.convert = mock_convert
 
+
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_text_search_none(self, query):
         query.return_value = self.mock_query
@@ -61,7 +62,7 @@ class TestGleanerSearch(unittest.TestCase):
         )
         results = self.search.text_search(text='test', page_number=5)
         self.assertEqual(results, expected)
-        self.assertIn('?lit bds:search "test"', self.search.query)
+        self.assertIn("?lit bds:search '''test'''", self.search.query)
 
     @patch('SPARQLWrapper.SPARQLWrapper.query')
     def test_date_filter_none(self, query):

--- a/app/tests/search/test_gleaner.py
+++ b/app/tests/search/test_gleaner.py
@@ -155,7 +155,7 @@ class TestGleanerSearch(unittest.TestCase):
         )
         self.assertEqual(results, expected)
 
-        self.assertIn('?lit bds:search "test"', self.search.query)
+        self.assertIn("?lit bds:search '''test'''", self.search.query)
         self.assertIn(
             "FILTER(?start_date >= '1999-01-01'^^xsd:date)", self.search.query)
         self.assertIn(


### PR DESCRIPTION
- Don't overwhelm Sentry by logging 404s in it
- Make a real 404 page and route 404s to it
- Python logging library uses the old-style syntax
- Slightly better query input sanitization