### PR TITLE
Be less aggressive about logging 404s, distinguish sentry environments

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+from app import routes, template_helpers
 import logging
 import os
 import sentry_sdk
@@ -27,10 +28,6 @@ try:
 except OSError:
     pass
 
-from app import routes, template_helpers
-
-# Default, on production / non-debug environments
-app.logger.setLevel(logging.INFO)
 
 if __name__ == "__main__":
     # Only for debugging while developing

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,9 @@ except OSError:
 
 from app import routes, template_helpers
 
+# Default, on production / non-debug environments
+app.logger.setLevel(logging.INFO)
+
 if __name__ == "__main__":
     # Only for debugging while developing
     app.logger.setLevel(logging.DEBUG)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,3 @@
-from app import routes, template_helpers
 import logging
 import os
 import sentry_sdk
@@ -28,6 +27,7 @@ try:
 except OSError:
     pass
 
+from app import routes, template_helpers
 
 if __name__ == "__main__":
     # Only for debugging while developing

--- a/app/app_config.cfg
+++ b/app/app_config.cfg
@@ -14,3 +14,5 @@ if not GLEANER_ENDPOINT_URL:
     raise ValueError("No GLEANER_ENDPOINT_URL set for Flask application - searches will fail.")
 
 CACHE_BUSTER_CONFIG = { 'extensions': ['.js', '.css'], 'hash_size': 5 }
+
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")

--- a/app/routes.py
+++ b/app/routes.py
@@ -80,17 +80,17 @@ def combined_search():
 
 @app.errorhandler(NotFound)
 def handle_404(e):
-    logger.error("404 for url %s", request.url)
     return render_template("404.html", e=e), 404
 
 
 @app.errorhandler(Exception)
 def handle_exception(e):
-    logger.error("Exception while handling request for %s: %s", request.url, e)
-
     # Record it in Sentry if we're in production
     if app.debug == False:
         capture_exception(e)
+    else:
+        logger.error("Exception while handling request for %s: %s", request.url, e)
+
 
     # pass through HTTP errors
     if isinstance(e, HTTPException):

--- a/app/routes.py
+++ b/app/routes.py
@@ -89,8 +89,8 @@ def handle_exception(e):
     if app.debug == False:
         capture_exception(e)
     else:
-        logger.error("Exception while handling request for %s: %s", request.url, e)
-
+        logger.error(
+            "Exception while handling request for %s: %s", request.url, e)
 
     # pass through HTTP errors
     if isinstance(e, HTTPException):

--- a/app/routes.py
+++ b/app/routes.py
@@ -89,7 +89,7 @@ def handle_exception(e):
     if app.debug == False:
         capture_exception(e)
     else:
-        logger.error(
+        logger.exception(
             "Exception while handling request for %s: %s", request.url, e)
 
     # pass through HTTP errors

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -110,6 +110,8 @@ services:
       - FLASK_RUN_HOST
       - SECRET_KEY
       - FLASK_ENV
+      - SENTRY_DSN
+      - SENTRY_ENVIRONMENT
       # These are both for running in a subdirectory. IF you don't want to do that,
       # you can delete the next two lines.
       # - SERVER_NAME=None

--- a/helm/templates/web-deployment.yaml
+++ b/helm/templates/web-deployment.yaml
@@ -59,6 +59,8 @@ spec:
             secretKeyRef:
               key: sentryDsn
               name: {{ .Release.Name }}-secrets
+        - name: SENTRY_ENVIRONMENT
+          value: {{ .Values.sentryEnvironment }}
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -108,6 +108,8 @@ javaXMS: 2g
 javaXmx: 8g
 javaOpts: -Xmx6g -Xms2g --XX:+UseG1GC
 
+sentryEnvironment: development
+
 storageNamespace: polder
 
 ## Persist data to a persistent volume.

--- a/helm/values-local.yaml
+++ b/helm/values-local.yaml
@@ -103,6 +103,8 @@ javaXMS: 2g
 javaXmx: 8g
 javaOpts: -Xmx6g -Xms2g --XX:+UseG1GC
 
+sentryEnvironment: local
+
 storageNamespace: polder
 
 ## Persist data to a persistent volume.

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -108,6 +108,8 @@ javaXMS: 2g
 javaXmx: 8g
 javaOpts: -Xmx6g -Xms2g --XX:+UseG1GC
 
+sentryEnvironment: production
+
 storageNamespace: polder
 
 ## Persist data to a persistent volume.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gunicorn==20.1.0
 python-dotenv==0.20.0
 requests==2.26.0
 requests-mock==1.9.3
-sentry-sdk==1.5.6
+sentry-sdk==1.6.0
 SPARQLWrapper==1.8.5
 typing-extensions==3.10.0.2
 validators==0.20.0


### PR DESCRIPTION
This solves a couple of problems:

- By logging 404s, I was creating a lot of noise in our error reporting software and causing it to go over its quota. I hadn't realized that `logger.error` would log a separate entry from `capture_exception`. So all the 404s were being logged in there and any legitimate errors were being logged *twice* (https://trello.com/c/qD75aDZs)
- 
- I can now filter between 'dev', 'production', and 'local' in there more easily (https://trello.com/c/XNZPY3UP)

I think we have to start paying for it if I invite you, annoyingly, so this is a good one to get into LastPass.