### PR TITLE
Move the limit and offset clauses to a place that ensures the presenc…

### DIFF
--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -81,11 +81,11 @@ class GleanerSearch(SearcherBase):
                 UNION
                 {{
                     {base_query}
+                    OFFSET {page_start}
+                    LIMIT {GleanerSearch.PAGE_SIZE}
                 }}
             }}
             ORDER BY DESC(?total_results) DESC(?score)
-            OFFSET {page_start}
-            LIMIT {GleanerSearch.PAGE_SIZE}
         """
 
     @staticmethod

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.42.0"
+appVersion: "1.42.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
…e of total_results

For https://trello.com/c/4ADSEtqc

The problem was that we now use a slightly different query structure to fetch the total number of results to make paging work, and there was a bug that made the `total_results` field appear in the first page of results, but not any subsequent pages.

The fix was to move the `LIMIT` and `OFFSET` clauses to affect only the part of the query that fetches the data, and not the part of the query that does the count.