### PR TITLE
Bump up GraphDB heap size to the recommended amount

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -105,7 +105,7 @@ tolerations: []
 affinity: {}
 
 GDB_JAVA_OPTS: >-
-  -Xmx2g -Xms2g
+  -Xmx6g -Xms6g
   -Dgraphdb.home=/opt/graphdb/home
   -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
   -Dgraphdb.workbench.cors.enable=true

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -105,7 +105,7 @@ tolerations: []
 affinity: {}
 
 GDB_JAVA_OPTS: >-
-  -Xmx6g -Xms6g
+  -Xmx6g -Xms2g
   -Dgraphdb.home=/opt/graphdb/home
   -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
   -Dgraphdb.workbench.cors.enable=true

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -105,7 +105,7 @@ tolerations: []
 affinity: {}
 
 GDB_JAVA_OPTS: >-
-  -Xmx2g -Xms2g
+  -Xmx6g -Xms6g
   -Dgraphdb.home=/opt/graphdb/home
   -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
   -Dgraphdb.workbench.cors.enable=true

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -105,7 +105,7 @@ tolerations: []
 affinity: {}
 
 GDB_JAVA_OPTS: >-
-  -Xmx6g -Xms6g
+  -Xmx6g -Xms2g
   -Dgraphdb.home=/opt/graphdb/home
   -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
   -Dgraphdb.workbench.cors.enable=true


### PR DESCRIPTION
Today, @yemoski noticed that some search-dev queries were failing. This was because GraphDB was running out of memory for large result sets, and bailing out.

I noticed that we have the maximum heap size for GraphDB set to 2GB, but the documentation recommends a maximum of 6GB: https://graphdb.ontotext.com/documentation/10.0/configuring-a-repository.html#configure-graphdb-memory

Hopefully this will help.