### PR TITLE
Do not try to show geometries that do not exist, bump version

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -14,11 +14,13 @@
    <ul id='main-content' class="results">
    {% for result in result_set.results %}
     <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id }}" id="{{ loop.index }}">
-      <!-- todo: separate out the result locations and template rendering
-       so that we aren't calling these from each result object directly. This feels kind of gross. -->
-      <script type="text/javascript">
-        resultGeometries["{{ result.title }}"] = {{ result.geometry | tojson | safe }};
-      </script>
+      {% if result.geometry %}
+        <!-- todo: separate out the result locations and template rendering
+         so that we aren't calling these from each result object directly. This feels kind of gross. -->
+        <script type="text/javascript">
+          resultGeometries["{{ result.title }}"] = {{ result.geometry | tojson | safe }};
+        </script>
+      {% endif %}
       {% if result.doi %}
         <div class="result__doi">
           <a href="http://doi.org/{{ result.doi }}" class="doi__link" target="_blank" rel="noopener">

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: nein09/polder-federated-search:1.42.5
+    image: nein09/polder-federated-search:1.43.1
     depends_on:
       - triplestore
       - s3system

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.42.5"
+appVersion: "1.43.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.42.5",
+  "version": "1.43.1",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
When I was developing the map locally, I didn't have a Gleaner index built, so I was only getting DataONE results. When I deployed it to search-dev, suddenly I had results with no geometries, and Javascript errors to go with them.