### PR TITLE
Sentry and Google Analytics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,8 @@ except OSError:
 def inject_google_analytics_id():
     return dict(google_analytics_id=app.config['GOOGLE_ANALYTICS_ID'])
 
+from app import routes, template_helpers
+
 
 if __name__ == "__main__":
     # Only for debugging while developing

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,6 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from flask_caching import Cache
 
 
-
-
-
 cache = Cache()
 
 sentry_sdk.init(
@@ -36,13 +33,13 @@ try:
 except OSError:
     pass
 
-from app import routes, template_helpers
+
+@app.context_processor
+def inject_google_analytics_id():
+    return dict(google_analytics_id=app.config['GOOGLE_ANALYTICS_ID'])
 
 
 if __name__ == "__main__":
     # Only for debugging while developing
     app.logger.setLevel(logging.DEBUG)
     app.run(host='0.0.0.0', debug=True, port=5000)
-
-    
-

--- a/app/app_config.cfg
+++ b/app/app_config.cfg
@@ -16,3 +16,5 @@ if not GLEANER_ENDPOINT_URL:
 CACHE_BUSTER_CONFIG = { 'extensions': ['.js', '.css'], 'hash_size': 5 }
 
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
+
+GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", None)

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,7 +2,7 @@ import logging
 from flask import redirect, render_template, request, url_for
 from datetime import date
 from sentry_sdk import capture_exception
-from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.exceptions import HTTPException, NotFound, MethodNotAllowed
 
 from app import app
 from app.search.dataone import SolrDirectSearch
@@ -81,6 +81,19 @@ def combined_search():
 @app.errorhandler(NotFound)
 def handle_404(e):
     return render_template("404.html", e=e), 404
+
+@app.errorhandler(MethodNotAllowed)
+# There are a lot of bots on the internet that try to post garbage
+# to get-only routes, and other such shenanigans, and they are
+# making lots of noise in Sentry.
+# If we're running a dev server, it's good to see this error
+# message because maybe we're trying to write a REST endpoint.
+# But if we're in production, it's better to bypass it.
+def handle_405(e):
+    if app.debug == False:
+        return render_template("500_generic.html", e=e)
+    else:
+        return handle_exception(e)
 
 
 @app.errorhandler(Exception)

--- a/app/routes.py
+++ b/app/routes.py
@@ -82,6 +82,7 @@ def combined_search():
 def handle_404(e):
     return render_template("404.html", e=e), 404
 
+
 @app.errorhandler(MethodNotAllowed)
 # There are a lot of bots on the internet that try to post garbage
 # to get-only routes, and other such shenanigans, and they are
@@ -111,7 +112,3 @@ def handle_exception(e):
 
     # now you're handling non-HTTP exceptions only
     return render_template("500_generic.html", e=e), 500
-
-
-
-    

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,13 +7,13 @@
       <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/style.css') }}" />
       <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='img/favicon.ico') }}">
      <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-234464538-2"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{google_analytics_id}}></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'UA-234464538-2');
+      gtag('config', '{{ google_analytics_id} }');
     </script>
 
       <title>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,16 +6,17 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/style.css') }}" />
       <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='img/favicon.ico') }}">
-     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{google_analytics_id}}></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+     {% if google_analytics_id %}
+          <!-- Global site tag (gtag.js) - Google Analytics -->
+          <script async src="https://www.googletagmanager.com/gtag/js?id={{google_analytics_id}}"></script>
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
 
-      gtag('config', '{{ google_analytics_id} }');
-    </script>
-
+            gtag('config', '{{google_analytics_id}}');
+          </script>
+      {% endif %}
       <title>
           {% block title %}Home{% endblock %} - POLDER Federated Search
       </title>

--- a/dev.env
+++ b/dev.env
@@ -29,3 +29,6 @@ export GLEANER_GRAPH=${GLEANER_BASE}/datavol/graph
 
 # Kubernetes deployment helper
 export KUBECONFIG=~/.kube/config:~/polder-federated-search/helm/polder.config
+
+# Google Analytics property ID
+export GOOGLE_ANALYTICS_ID=

--- a/dev.env
+++ b/dev.env
@@ -10,6 +10,7 @@ export FLASK_ENV=development
 
 # Setup for Sentry, our error tracking software
 export SENTRY_DSN=
+export SENTRY_ENVIRONMENT=development
 
 # If you are using docker-compose to run the other services, and flask run for development
 # If you are using GraphDB for your triplestore:

--- a/helm/templates/web-deployment.yaml
+++ b/helm/templates/web-deployment.yaml
@@ -61,6 +61,8 @@ spec:
               name: {{ .Release.Name }}-secrets
         - name: SENTRY_ENVIRONMENT
           value: {{ .Values.sentryEnvironment }}
+        - name: GOOGLE_ANALYTICS_ID
+          value: {{ .Values.googleAnalyticsId }}
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -116,6 +116,7 @@ GDB_JAVA_OPTS: >-
   -Dreuse.vars.in.subselects=true
 
 sentryEnvironment: development
+googleAnalyticsId: UA-234464538-2
 
 storageNamespace: polder
 

--- a/helm/values-local.yaml
+++ b/helm/values-local.yaml
@@ -111,6 +111,7 @@ GDB_JAVA_OPTS: >-
   -Dreuse.vars.in.subselects=true
 
 sentryEnvironment: local
+googleAnalyticsId: UA-234464538-2
 
 storageNamespace: polder
 

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -116,6 +116,7 @@ GDB_JAVA_OPTS: >-
   -Dreuse.vars.in.subselects=true
 
 sentryEnvironment: production
+googleAnalyticsId: UA-234464538-2
 
 storageNamespace: polder
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pygeojson==0.2.0
 python-dotenv==0.20.0
 requests==2.26.0
 requests-mock==1.9.3
-sentry-sdk==1.6.0
+sentry-sdk==1.9.5
 SPARQLWrapper==1.8.5
 typing-extensions==3.10.0.2
 validators==0.20.0


### PR DESCRIPTION
I don't normally like to pile multiple fixes into one branch, but here we are. This has:

- an upgrade to the Sentry Python API
- Better handling for 405 errors, because people are using bots to try weird stuff on our server and it's clogging up our error reporting system with junk
- A way to set the Google Analytics IDs as an environment variable, so that we can set different IDs per-deployment, using Helm