### PR TITLE
Mostly map touchups

### DIFF
--- a/app/search/gleaner.py
+++ b/app/search/gleaner.py
@@ -77,7 +77,7 @@ class GleanerSearch(SearcherBase):
                     ?geo a schema:GeoCoordinates .
                     ?geo schema:longitude ?lon.
                     ?geo schema:latitude ?lat .
-                    BIND(concat('str(?lat), " ", str(?lon)') as ?spatial_coverage_point )  .
+                    BIND(concat(str(?lat), " ", str(?lon)) as ?spatial_coverage_point )  .
                 }}
 
                 OPTIONAL {{

--- a/app/static/css/_constants.scss
+++ b/app/static/css/_constants.scss
@@ -12,6 +12,7 @@ $grey: #999;
 
 /* Type */
 $font-weight-bold: 800;
+$font-weight-normal: 400;
 $font-weight-light: 200;
 
 /* Breakpoints */

--- a/app/static/css/_elements.scss
+++ b/app/static/css/_elements.scss
@@ -22,10 +22,12 @@ a {
 h1 {
     color: constants.$dark-blue;
     font-size: 1.5rem;
+    margin-top: 0.5rem;
     text-align: center;
 
     @include constants.breakpoint(medium-and-up) {
         font-size: 2rem;
+        margin-top: inherit;;
         text-align: left;
     }
 }

--- a/app/static/css/_form.scss
+++ b/app/static/css/_form.scss
@@ -2,6 +2,7 @@
 
 .search__header {
     color: constants.$dark-blue;
+    font-weight: normal;
     padding: 0 0.25rem;
 
     @include constants.breakpoint(medium-and-up) {
@@ -18,6 +19,11 @@
 
 .search__label {
     font-weight: constants.$font-weight-bold;
+    padding: 0.6rem 0;
+}
+
+.search__label--secondary {
+    font-weight: constants.$font-weight-normal;
     padding: 0.6rem 0;
 }
 
@@ -92,11 +98,11 @@
 .date-picker {
     justify-content: flex-start;
     margin: 0;
-    padding: 0.5rem 0;
 }
 
 .date-picker__group {
     flex: 0 1 auto;
+    padding: 0.5rem 0;
 }
 
 

--- a/app/static/css/_form.scss
+++ b/app/static/css/_form.scss
@@ -105,15 +105,16 @@
     padding: 0.5rem 0;
 }
 
-
 .loading {
     width: 100%; 
     margin:  auto;
     display: none;
     background-color: constants.$soft-white;
+    opacity: 90%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
 }
-
-
 
 .loader-wheel {
   animation: spin 1s infinite linear;
@@ -121,8 +122,7 @@
   border-left: 4px solid #fff;
   border-radius: 50%;
   height: 50px;
-  margin: auto;
-  margin-bottom: 10px;
+  margin: 3rem auto 1rem;
   width: 50px;
 }
 
@@ -133,7 +133,6 @@
   text-align: center;
   margin-left: auto;
   margin-right: auto;
-
 }
 
 .loader-text:after {

--- a/app/static/css/_map.scss
+++ b/app/static/css/_map.scss
@@ -1,9 +1,18 @@
+@use 'constants';
 @import 'npm:ol/ol.css';
 
 .map__container {
-    display: flex;
-    flex-flow: row wrap;
-    padding: 0 3rem;
+    display: block;
+    padding: 0 0.5rem;
+
+    @include constants.breakpoint(medium-and-up) {
+        padding: 0 1rem;
+    }
+
+    @include constants.breakpoint(large-and-up) {
+        display: flex;
+        flex-flow: row wrap;
+    }
 }
 
 .map {

--- a/app/static/css/_nav.scss
+++ b/app/static/css/_nav.scss
@@ -5,8 +5,7 @@
     background-color: constants.$soft-white;
     border-bottom: 2px solid constants.$light-blue;
     margin: 0;
-    padding: 0.5rem;
-    padding-bottom: 0.25rem;
+    padding: 0.25rem 0.5rem;
 
     @include constants.breakpoint(medium-and-up) {
         padding: 1rem;

--- a/app/static/css/_results.scss
+++ b/app/static/css/_results.scss
@@ -36,6 +36,7 @@
 }
 
 .result__doi {
+    height: 1rem;
     padding: 0.25rem;
     text-align: right;
 }
@@ -123,10 +124,20 @@
   
 }
 
-.data_source img{
-    max-width: 200px;
-    display: block;
-    margin: 1rem 0;
+.data_source {
+    text-align: right;
+}
+
+.data_source__link {
+    color: constants.$dark-blue;
+    font-weight: constants.$font-weight-bold;
+}
+
+.data_source .data_source__image {
+    max-width: 50px;
+    display: inline;
+    margin: 0.25rem;
+    vertical-align: middle;
 }
 
 

--- a/app/static/css/_results.scss
+++ b/app/static/css/_results.scss
@@ -10,8 +10,6 @@
     }
 }
 
-
-
 .results {
     background-color: constants.$soft-white;
     list-style:  none;

--- a/app/static/css/_results.scss
+++ b/app/static/css/_results.scss
@@ -113,6 +113,7 @@
         text-align: left;
         overflow: hidden;
 }
+
 .screenreader-text:focus {
         left: 0;
         top: 0;

--- a/app/static/css/_results.scss
+++ b/app/static/css/_results.scss
@@ -104,8 +104,6 @@
     
 }
 
-.results__container--no-js .result--full { display: inline-block; }
-
 .screenreader-text {
         position: absolute;
         top: -1000px;

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -265,11 +265,16 @@ const displayResult = function (map, pixel) {
     }
 };
 
+const mapContainer = $(".map__container");
+const arcticScreenReaderList = $("#map__screenreader--arctic");
+const antarcticScreenReaderList = $("#map__screenreader--antarctic");
+
+
 export function initializeMaps() {
     arcticResultsSource.clear(true);
     antarcticResultsSource.clear(true);
 
-    $(".map__container").removeClass("hidden");
+    mapContainer.removeClass("hidden");
 
 
     if (!arcticMap) {
@@ -301,6 +306,7 @@ export function initializeMaps() {
                 [new Attribution({collapsible: true,})]
             ),
         });
+
         antarcticMap.on("click", function (evt) {
             displayResult(antarcticMap, evt.pixel);
         });
@@ -308,6 +314,7 @@ export function initializeMaps() {
 }
 
 export function addSearchResult(name, geometry) {
+
     const arcticFeature = new GeoJSON().readFeature(geometry, {
         // If your tileset is using the default projection, don't need the next two lines.
         dataProjection: getProjection("ESPG:4326"),
@@ -324,6 +331,7 @@ export function addSearchResult(name, geometry) {
         // Can we reproject it in GeoSPARQL or something?
         arcticFeature.set("name", name);
         arcticResultsSource.addFeature(arcticFeature);
+        arcticScreenReaderList.append(`<li>${name}</li>`);
     }
 
     const antarcticFeature = new GeoJSON().readFeature(geometry, {
@@ -341,5 +349,6 @@ export function addSearchResult(name, geometry) {
         // todo: let's set these in the geojson on the server side.
         antarcticFeature.set("name", name);
         antarcticResultsSource.addFeature(antarcticFeature);
+        antarcticScreenReaderList.append(`<li>${name}</li>`);
     }
 }

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -271,16 +271,22 @@ const displayResult = function (map, pixel) {
     }
 };
 
-const mapContainer = $(".map__container");
-const arcticScreenReaderList = $("#map__screenreader--arctic");
-const antarcticScreenReaderList = $("#map__screenreader--antarctic");
+const $mapContainer = $(".map__container");
+let $arcticScreenReaderList = $("#map__screenreader--arctic");
+let $antarcticScreenReaderList = $("#map__screenreader--antarctic");
 
 
 export function initializeMaps(lazy=false) {
+    $arcticScreenReaderList = $("#map__screenreader--arctic");
+    $antarcticScreenReaderList = $("#map__screenreader--antarctic");
+
+    $arcticScreenReaderList.empty();
+    $antarcticScreenReaderList.empty();
+
     arcticResultsSource.clear(true);
     antarcticResultsSource.clear(true);
 
-    mapContainer.removeClass("hidden");
+    $mapContainer.removeClass("hidden");
 
 
     if (!lazy || !arcticMap) {
@@ -339,7 +345,7 @@ export function addSearchResult(name, geometry) {
         // Can we reproject it in GeoSPARQL or something?
         arcticFeature.set("name", name);
         arcticResultsSource.addFeature(arcticFeature);
-        arcticScreenReaderList.append(`<li>${name}</li>`);
+        $arcticScreenReaderList.append(`<li>${name}</li>`);
     }
 
     const antarcticFeature = new GeoJSON().readFeature(geometry, {
@@ -357,6 +363,6 @@ export function addSearchResult(name, geometry) {
         // todo: let's set these in the geojson on the server side.
         antarcticFeature.set("name", name);
         antarcticResultsSource.addFeature(antarcticFeature);
-        antarcticScreenReaderList.append(`<li>${name}</li>`);
+        $antarcticScreenReaderList.append(`<li>${name}</li>`);
     }
 }

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -18,6 +18,8 @@ import VectorTileSource from "ol/source/VectorTile";
 import { Circle, Text, Fill, Stroke, Style } from "ol/style";
 import View from "ol/View";
 
+const pixel_ratio = parseInt(window.devicePixelRatio) || 1;
+
 // PROJECTIONS: If you are using default map projections, you don't need any of this stuff.
 const arcticExtent = 6378137 * Math.PI; // Extent is half of the WGS84 Ellipsoid equatorial circumference.
 const arcticExtentBoundary = [
@@ -26,6 +28,7 @@ const arcticExtentBoundary = [
     arcticExtent,
     arcticExtent,
 ];
+
 const arcticTileSize = 512;
 const arcticMaxZoom = 18;
 
@@ -39,9 +42,8 @@ const antarcticExtentBoundary = [
 const antarcticTileSize = 256;
 const antarcticMaxZoom = 16;
 
-const pixel_ratio = parseInt(window.devicePixelRatio) || 1;
-
-// Set up the map projections for standard polar views.
+// Set up the map projections for standard polar views. If you're using Mercator,
+// you can delete these.
 proj4.defs([
     [
         "EPSG:3573",
@@ -62,8 +64,8 @@ let antarcticProjection = getProjection("EPSG:3031");
 antarcticProjection.setExtent(antarcticExtentBoundary);
 
 
-// EXTRA PLACES: if your map tiles include all the place names you want already, you don't need any of this stuff.
-// Places and countries styles for the antarctic map
+// EXTRA PLACES: Places and countries styles for the antarctic map.
+// If your map tiles include all the place names you want already, you don't need these.
 const placesTextFill = new Fill({ color: "#222" });
 const countriesTextFill = new Fill({ color: "#ac46ac" });
 const placesTextStroke = new Stroke({
@@ -95,7 +97,7 @@ const countriesTextStyle = function (feature) {
     });
 };
 
-// SEARCH RESULTS: customize these styles to match your colors
+// SEARCH RESULTS: customize these styles to match your colors and preferences
 const accentWarm = "#e66b3d"; // see _constants.scss
 const resultStroke = new Stroke({ color: accentWarm, width: 2 });
 const resultFill = new Fill({
@@ -125,6 +127,8 @@ const resultStyle = function (feature) {
 function getMinResolution(extent, tileSize, maxZoom) {
     return extent / (tileSize / 2) / Math.pow(2, maxZoom);
 }
+
+// VIEWS: if you have one map, you only need one view.
 
 // This tileset does not work correctly when you specify a projection for some reason,
 // even though it uses a non-standard projection.
@@ -188,6 +192,7 @@ fetch("/static/maps/style.json").then(function (response) {
     });
 });
 
+// EXTRA PLACES:
 // If your map already has all the place names you want on it, you don't need this part.
 // These two layers are just to put some labels on Antarctica to make
 // the map more usable.
@@ -226,6 +231,7 @@ fetch("/static/maps/countries.geojson").then(function (response) {
     });
 });
 
+// LAYERS:
 // A layer for the search results, on each map. You definitely need this
 // part (although if you only have one map, you only need one of them)
 let arcticResultsSource = new VectorSource({});
@@ -315,6 +321,8 @@ export function initializeMaps(lazy=false) {
 
 export function addSearchResult(name, geometry) {
 
+    // We're adding features twice in here because there are two maps.
+    // If you only have one map, you only need to do this once.
     const arcticFeature = new GeoJSON().readFeature(geometry, {
         // If your tileset is using the default projection, don't need the next two lines.
         dataProjection: getProjection("ESPG:4326"),

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -270,14 +270,14 @@ const arcticScreenReaderList = $("#map__screenreader--arctic");
 const antarcticScreenReaderList = $("#map__screenreader--antarctic");
 
 
-export function initializeMaps() {
+export function initializeMaps(lazy=false) {
     arcticResultsSource.clear(true);
     antarcticResultsSource.clear(true);
 
     mapContainer.removeClass("hidden");
 
 
-    if (!arcticMap) {
+    if (!lazy || !arcticMap) {
         arcticMap = new Map({
             target: "map--arctic",
             view: arcticView,
@@ -292,7 +292,7 @@ export function initializeMaps() {
         });
     }
 
-    if (!antarcticMap) {
+    if (!lazy || !antarcticMap) {
         antarcticMap = new Map({
             target: "map--antarctic",
             view: antarcticView,

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import proj4 from "proj4";
 import { applyStyle, stylefunction } from "ol-mapbox-style";
 
+import {Attribution, defaults as defaultControls} from 'ol/control';
 import { containsExtent } from "ol/extent";
 import GeoJSON from "ol/format/GeoJSON";
 import MVT from "ol/format/MVT";
@@ -53,6 +54,7 @@ proj4.defs([
 ]);
 register(proj4);
 
+// Polar projections; if you're sticking to Mercator, you don't need these.
 let arcticProjection = getProjection("EPSG:3573");
 arcticProjection.setExtent(arcticExtentBoundary);
 
@@ -269,11 +271,15 @@ export function initializeMaps() {
 
     $(".map__container").removeClass("hidden");
 
+
     if (!arcticMap) {
         arcticMap = new Map({
             target: "map--arctic",
             view: arcticView,
             layers: [arcticLayer, arcticResultsLayer],
+            controls: defaultControls({attribution: false}).extend(
+                [new Attribution({collapsible: true})]
+            ),
         });
 
         arcticMap.on("click", function (evt) {
@@ -291,6 +297,9 @@ export function initializeMaps() {
                 antarcticPlacesLayer,
                 antarcticResultsLayer,
             ],
+            controls: defaultControls({attribution: false}).extend(
+                [new Attribution({collapsible: true,})]
+            ),
         });
         antarcticMap.on("click", function (evt) {
             displayResult(antarcticMap, evt.pixel);

--- a/app/static/js/search.js
+++ b/app/static/js/search.js
@@ -34,7 +34,8 @@ function handleSearchResults($ajaxPromise) {
     })
     .always(function () {
       $searchButton.prop("disabled", false);
-      $resultsContainer.focus();
+      $resultsContainer[0].focus();
+      $resultsContainer[0].scrollIntoView();
       load.style.display = "none";
       initializeMaps();
       for (const [name, geometry] of Object.entries(resultGeometries)) {

--- a/app/static/maps/README.md
+++ b/app/static/maps/README.md
@@ -8,7 +8,7 @@ If you want to make your own map styles, you can do it in [Mapbox Studio](https:
 
 We also found some places and geographic features in Antarctica to put on the map, since the tileset we're using from GBIF doesn't have them; that's `places.geojson`, and `countries.geojson` for more zoomed-out views.
 
-Note that the Arctic and Antarctic map use different projections, and neither of them are the default web map projections. If you wish to adapt this app and just have one map, that is web mercator, you can simplify the code quite a bit.
+Note that the Arctic and Antarctic map use different projections, and neither of them are the default web map projections. If you wish to adapt this app and just have one map (most likely web mercator), you can simplify the code quite a bit.
 
 ### Other helpful resources:
 - [MapTiler](https://www.maptiler.com/)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -45,6 +45,11 @@
       </section>
       {% block js %}
         <script type="module" src="{{ url_for('static', filename='dist/js/index.js') }}"></script>
+        <!-- for the search results showing up on the maps. Temporary until
+        these geometries are returned with an API. -->
+        <script type="text/javascript">
+        let resultGeometries = {};
+    </script>
       {% endblock %}
   </body>
 </html>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -38,9 +38,6 @@
       </nav>
       {% endblock %}
       <section class="content">
-        <header>
-          {% block header %}{% endblock %}
-        </header>
         {% for message in get_flashed_messages() %}
           <div class="flash">{{ message }}</div>
         {% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -50,7 +50,7 @@
 <div class="map__container hidden">
     <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
         <div class="screenreader-text">
-            A polar-projected map of the Arctic, with regions indicated for the spatial coverage of the following datasets:
+            A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
             <ul id="map__screenreader--arctic">
             </ul>
         </div>
@@ -58,7 +58,7 @@
     </div>
     <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
         <div class="screenreader-text">
-            A polar-projected map of the Antarctic, with regions indicated for the spatial coverage of the following datasets:
+            A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
             <ul id="map__screenreader--antarctic">
             </ul>
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -48,8 +48,21 @@
 </div>
 
 <div class="map__container hidden">
-    <div class="map map--arctic" id="map--arctic" tabindex="0"></div>
-    <div class="map map--antarctic" id="map--antarctic" tabindex="0"></div>
+    <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
+        <div class="screenreader-text">
+            A polar-projected map of the Arctic, with regions indicated for the spatial coverage of the following datasets:
+            <ul id="map__screenreader--arctic">
+            </ul>
+        </div>
+
+    </div>
+    <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
+        <div class="screenreader-text">
+            A polar-projected map of the Antarctic, with regions indicated for the spatial coverage of the following datasets:
+            <ul id="map__screenreader--antarctic">
+            </ul>
+        </div>
+    </div>
 </div>
 
 <!-- for the search results showing up on the maps. Temporary until

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -51,28 +51,30 @@
     <div class="loader-text"></div>
 </div>
 
-<div class="map__container hidden">
-    <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
-        <div class="screenreader-text">
-            A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
-            <ul id="map__screenreader--arctic">
-            </ul>
-        </div>
+{% if nojs is not defined %}
+    <div class="map__container hidden">
+        <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
+            <div class="screenreader-text">
+                A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
+                <ul id="map__screenreader--arctic">
+                </ul>
+            </div>
 
-    </div>
-    <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
-        <div class="screenreader-text">
-            A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
-            <ul id="map__screenreader--antarctic">
-            </ul>
+        </div>
+        <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
+            <div class="screenreader-text">
+                A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
+                <ul id="map__screenreader--antarctic">
+                </ul>
+            </div>
         </div>
     </div>
-</div>
 
-<!-- for the search results showing up on the maps. Temporary until
-    these geometries are returned with an API. -->
-<script type="text/javascript">
-  let resultGeometries = {};
-</script>
+    <!-- for the search results showing up on the maps. Temporary until
+        these geometries are returned with an API. -->
+    <script type="text/javascript">
+      let resultGeometries = {};
+    </script>
+{% endif %}
 <div class="results__container" tabindex="-1"></div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<div class="container">
+<div class="container container--search" role="search">
     <h2 class="search__header">Use any or all of the fields below to search for datasets about Earth's polar regions.</h2>
     <!-- in the absence of JS, the form displays results at /search -->
     <form class="search" method="get" action="{{ url_for('nojs_combined_search') }}" data-api-url="{{ url_for('combined_search') }}">
@@ -48,8 +48,8 @@
 </div>
 
 <div class="map__container hidden">
-    <div class="map map--arctic" id="map--arctic"></div>
-    <div class="map map--antarctic" id="map--antarctic"></div>
+    <div class="map map--arctic" id="map--arctic" tabindex="0"></div>
+    <div class="map map--antarctic" id="map--antarctic" tabindex="0"></div>
 </div>
 
 <!-- for the search results showing up on the maps. Temporary until

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -51,30 +51,6 @@
     <div class="loader-text"></div>
 </div>
 
-{% if nojs is not defined %}
-    <div class="map__container hidden">
-        <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
-            <div class="screenreader-text">
-                A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
-                <ul id="map__screenreader--arctic">
-                </ul>
-            </div>
-
-        </div>
-        <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
-            <div class="screenreader-text">
-                A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
-                <ul id="map__screenreader--antarctic">
-                </ul>
-            </div>
-        </div>
-    </div>
-
-    <!-- for the search results showing up on the maps. Temporary until
-        these geometries are returned with an API. -->
-    <script type="text/javascript">
-      let resultGeometries = {};
-    </script>
-{% endif %}
 <div class="results__container" tabindex="-1"></div>
+
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,27 +12,31 @@
             <span class="validity"></span>
         </div>
         <fieldset class="search__field">
-            <legend class="search__label">Search for date ranges representing when data was collected:</legend>
+            <legend class="search__label">Search for date ranges representing when data was collected</legend>
             <div class="date-picker__group">
-                {% with id="start_min", label_text="Starting on or after:" %}
+                <legend class="search__label">Data collection began between</legend>
+                {% with id="start_min", label_text="Start date:" %}
                     {% include 'partials/date-picker.html' %}
                 {% endwith %}
-                {% with id="start_max", label_text="Starting on or before:" %}
+                <div class="date-picker__and">and</div>
+                {% with id="start_max", label_text="End date:" %}
                     {% include 'partials/date-picker.html' %}
                 {% endwith %}
             </div>
             <div class="date-picker__group">
-                {% with id="end_min", label_text="Ending on or after:" %}
+                <legend class="search__label">Data collection ended between</legend>
+                {% with id="end_min", label_text="Start date:" %}
                     {% include 'partials/date-picker.html' %}
                 {% endwith %}
-                {% with id="end_max", label_text="Ending on or before:" %}
+                <div class="date-picker__and">and</div>
+                {% with id="end_max", label_text="End date:" %}
                     {% include 'partials/date-picker.html' %}
                 {% endwith %}
             </div>
             
         </fieldset>
         <div class="search__field">
-           <label class="search__label author" for="author">Search for Author Name </label>
+           <label class="search__label author" for="author">Search for authors named:</label>
         <input name="author" id="author"> 
 
         </div>

--- a/app/templates/partials/date-picker.html
+++ b/app/templates/partials/date-picker.html
@@ -1,5 +1,5 @@
 <div class="search__field date-picker">
-  <label class="search__label" for="{{ id}}">{{ label_text }}</label>
+  <label class="search__label--secondary" for="{{ id}}">{{ label_text }}</label>
   <input type="date" id="{{ id }}" name="{{ id }}">
   <span class="validity"></span>
 </div>

--- a/app/templates/partials/map.html
+++ b/app/templates/partials/map.html
@@ -1,0 +1,25 @@
+{% if nojs is not defined %}
+    <div class="map__container hidden">
+        <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
+            <div class="screenreader-text">
+                A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
+                <ul id="map__screenreader--arctic">
+                </ul>
+            </div>
+
+        </div>
+        <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
+            <div class="screenreader-text">
+                A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
+                <ul id="map__screenreader--antarctic">
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- for the search results showing up on the maps. Temporary until
+        these geometries are returned with an API. -->
+    <script type="text/javascript">
+      resultGeometries = {};
+    </script>
+{% endif %}

--- a/app/templates/partials/map.html
+++ b/app/templates/partials/map.html
@@ -1,6 +1,6 @@
 {% if nojs is not defined %}
     <div class="map__container hidden">
-        <div class="map map--arctic" id="map--arctic" tabindex="0" role="region-arctic" aria-roledescription="map">
+        <div class="map map--arctic" id="map--arctic" tabindex="0" role="region" aria-roledescription="map-arctic">
             <div class="screenreader-text">
                 A polar-projected map of the Arctic, with boundaries drawn for the spatial coverage of the following datasets:
                 <ul id="map__screenreader--arctic">
@@ -8,7 +8,7 @@
             </div>
 
         </div>
-        <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region-antarctic" aria-roledescription="map">
+        <div class="map map--antarctic" id="map--antarctic" tabindex="0" role="region" aria-roledescription="map-antarctic">
             <div class="screenreader-text">
                 A polar-projected map of the Antarctic, with boundaries drawn for the spatial coverage of the following datasets:
                 <ul id="map__screenreader--antarctic">

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -1,116 +1,114 @@
 
 {% if result_set.results %}
-<a class="screenreader-text" href="#main-content">
-  skip to results
-</a>
-{% with pages=result_set.available_pages, current_page=result_set.page_number %}
+  <a class="screenreader-text" href="#main-content">
+    skip to results
+  </a>
+
+  {% with pages=result_set.available_pages, current_page=result_set.page_number %}
     {% include 'partials/paginator.html' %}
   {% endwith %}
 
-<script type="text/javascript">
-  resultGeometries = {};
-</script>
+  <script type="text/javascript">
+    resultGeometries = {};
+  </script>
 
    <ul id='main-content' class="results">
-   {% for result in result_set.results %}
-    <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id }}" id="{{ loop.index }}">
-      {% if result.geometry %}
-        <!-- todo: separate out the result locations and template rendering
-         so that we aren't calling these from each result object directly. This feels kind of gross. -->
-        <script type="text/javascript">
-          resultGeometries["{{ result.title }}"] = {{ result.geometry.geometry_collection | tojson | safe }};
-        </script>
-      {% endif %}
-      {% if result.doi %}
-        <div class="result__doi">
-          <a href="http://doi.org/{{ result.doi }}" class="doi__link" target="_blank" rel="noopener">
-            {{ result.doi }}
-          </a>
-        </div>
-      {% endif %}
-      <a href="{{ result.urls | first }}" target="_blank" rel="noopener">
-        <h3 class="result__title">
-          {{ result.title }}
-        </h3>
-      </a>
-      
-      {% if result.geometry and result.geometry.text %}
-        <h4>Location:</h4>
-        {% for text in result.geometry.text %}
-          {{text}}{{ ", " if not loop.last else "" }}
-        {% endfor %}
-      {% endif %}
-
-      {% if result.keywords %}
-        <p class="result__keywords">
-          <h4>Keywords:</h4>
-          {% for keyword in result.keywords %}
-          {{ keyword }}&nbsp;
-          {% endfor %}
-        </p>
-      {% endif %}
-
-
-     
-       
-      {% if nojs is not defined %}
-        <div class="result_field result--truncated" role="region" aria-expanded="false">
-          <h4>Abstract:</h4>
-          {{ result.abstract|safe|truncate(500) }}
-           
-        </div>
-      {% endif %}
-
-      <div class="result_field result--full" role="region" {% if nojs is not defined %}aria-hidden="true"{% endif %}>
-         {% if result.author %}
-            <div class="author">
-                <h4>Author:</h4>
-                  {% for author in result.author %}
-                    {{ author }}
-                  {% endfor %}
-            </div>
+    {% for result in result_set.results %}
+      <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id }}" id="{{ loop.index }}">
+        {% if result.geometry %}
+          <!-- todo: separate out the result locations and template rendering
+          so that we aren't calling these from each result object directly. This feels kind of gross. -->
+          <script type="text/javascript">
+            resultGeometries["{{ result.title }}"] = {{ result.geometry.geometry_collection | tojson | safe }};
+          </script>
         {% endif %}
 
-        {% if result.temporal_coverage %}
-        <div class="timespan_covered"> 
-          <h4>Timespans covered:</h4>
-              <ul class="result__temporal-coverage">
-                    {% for time in result.temporal_coverage %}
-                    <li>{{ time }}</li>
-                  {% endfor %}
-              </ul>
+        <div class="result__doi">
+          <!-- making this div appear conditionally makes the result titles appear with an inconsistent top margin -->
+          {% if result.doi %}
+            <a href="http://doi.org/{{ result.doi }}" class="doi__link" target="_blank" rel="noopener">
+              {{ result.doi }}
+            </a>
+          {% endif %}
         </div>
-      {% endif %}
-      
-        <h4>Abstract:</h4>
-        {{ result.abstract|safe}}
+
+        <a href="{{ result.urls | first }}" target="_blank" rel="noopener">
+          <h3 class="result__title">
+            {{ result.title }}
+          </h3>
+        </a>
 
         {% if result.geometry and result.geometry.text %}
-              <div class="location">
-                <h4>Location:</h4>
-                  <span class="result__location">{{ result.geometry.coordinates }}</span>
-              </div>
+          <h4>Location:</h4>
+          {% for text in result.geometry.text %}
+            {{text}}
+          {% endfor %}
         {% endif %}
 
-        {% if result.license %}
-              <div class="license">
-                <h4>License:</h4>
-                  {{ result.license }}
-
-
-              </div>
+        {% if result.keywords %}
+          <p class="result__keywords">
+            <h4>Keywords:</h4>
+            {% for keyword in result.keywords %}
+              {{ keyword }}{{ ", " if not loop.last else "" }}
+            {% endfor %}
+          </p>
         {% endif %}
-        {% if result.datasource %}
-              <div class="data_source">
-                <h4>Original Source:</h4>
-                  {{ result.datasource['name'] }}
-                  <a href="{{ result.datasource['url'] }}" rel="noopener" target="_blank">
-                    {% if result.datasource['logo'] %}
-                        <img class="{{ result.datasource['key'] }}" src="{{ result.datasource['logo'] }}" alt="{{ result.datasource['name'] }}">
-                     {% endif %}
-                  </a>
-              </div>
+       
+        {% if nojs is not defined %}
+          <div class="result_field result--truncated" role="region" aria-expanded="false">
+            <h4>Abstract:</h4>
+              {{ result.abstract|safe|truncate(500) }}
+          </div>
         {% endif %}
+
+        <div class="result_field result--full" role="region" {% if nojs is not defined %}aria-hidden="true"{% endif %}>
+          {% if result.author %}
+            <div class="author">
+              <h4>Author(s):</h4>
+                {% for author in result.author %}
+                  {{ author }}{{ ", " if not loop.last else "" }}
+                {% endfor %}
+            </div>
+          {% endif %}
+
+          {% if result.temporal_coverage %}
+            <div class="timespan_covered">
+              <h4>Timespan(s) covered:</h4>
+                <ul class="result__temporal-coverage">
+                  {% for time in result.temporal_coverage %}
+                    <li>{{ time }}</li>
+                  {% endfor %}
+                </ul>
+            </div>
+          {% endif %}
+      
+          <h4>Abstract:</h4>
+          {{ result.abstract|safe}}
+
+          {% if result.geometry and result.geometry.text %}
+            <div class="location">
+              <h4>Location:</h4>
+              <span class="result__location">{{ result.geometry.coordinates }}</span>
+            </div>
+          {% endif %}
+
+          {% if result.license %}
+            <div class="license">
+              <h4>License:</h4>
+              {{ result.license }}
+            </div>
+          {% endif %}
+
+          {% if result.datasource %}
+            <div class="data_source">
+              <a class="data_source__link" href="{{ result.datasource['url'] }}" rel="noopener" target="_blank">
+                {{ result.datasource['name'] }}
+                {% if result.datasource['logo'] %}
+                  <img class="data_source__image {{ result.datasource['key'] }}" src="{{ result.datasource['logo'] }}" alt="{{ result.datasource['name'] }}">
+                {% endif %}
+              </a>
+            </div>
+          {% endif %}
         
       </div>
       <!-- only show the buttons if javascript is enabled (nojs not defined) -->
@@ -137,10 +135,10 @@
   {% endwith %}
 
 {% else %} {# No search results were returned. #}
-<div onclick="ga('send', 'event', 'Link', 'ZeroResults', 'example.com')" class="results results--empty">
-  <h3 id='zeroSearchResultsContainer'>No results were returned for your search.</h3>
-  {% if nojs %}
-    <a class="result__url" href="{{ url_for('home') }}">Please try again.</a>
-  {% endif %}
-</div>
+  <div onclick="ga('send', 'event', 'Link', 'ZeroResults', 'example.com')" class="results results--empty">
+    <h3 id='zeroSearchResultsContainer'>No results were returned for your search.</h3>
+    {% if nojs %}
+      <a class="result__url" href="{{ url_for('home') }}">Please try again.</a>
+    {% endif %}
+  </div>
 {% endif %}

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -104,9 +104,9 @@
               <div class="data_source">
                 <h4>Original Source:</h4>
                   {{ result.datasource['name'] }}
-                  <a  href={{ result.datasource['url'] }} rel="noopener" target="_blank">
+                  <a href="{{ result.datasource['url'] }}" rel="noopener" target="_blank">
                     {% if result.datasource['logo'] %}
-                        <img class={{ result.datasource['key'] }} src='{{ result.datasource['logo'] }}' alt= {{ result.datasource['name'] }}>
+                        <img class="{{ result.datasource['key'] }}" src="{{ result.datasource['logo'] }}" alt="{{ result.datasource['name'] }}">
                      {% endif %}
                   </a>
               </div>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -85,7 +85,7 @@
         <h4>Abstract:</h4>
         {{ result.abstract|safe}}
 
-        {% if result.geometry %}
+        {% if result.geometry and result.geometry.text %}
               <div class="location">
                 <h4>Location:</h4>
                   <span class="result__location">{{ result.geometry.coordinates }}</span>
@@ -115,13 +115,9 @@
       </div>
       <!-- only show the buttons if javascript is enabled (nojs not defined) -->
       {% if nojs is not defined %}
-        <button class="show_more_button" >Show more</button>
-        <button class="show_less_button" >Show less</button>
+        <button class="show_more_button">Show more</button>
+        <button class="show_less_button">Show less</button>
       {% endif %}
-      
-
-
-     
      
       {% for url in result.urls[1:] %}
         {% if loop.first %}Alternate sources for this data:{% endif %}

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -8,16 +8,17 @@
     {% include 'partials/paginator.html' %}
   {% endwith %}
 
-  <script type="text/javascript">
-    resultGeometries = {};
-  </script>
+  {% if nojs is not defined %}
+    {% include 'partials/map.html' %}
+  {% endif %}
 
    <ul id='main-content' class="results">
     {% for result in result_set.results %}
       <li class="result" data-score={{ result.score }} data-source="{{ result.source }}" data-id="{{ result.id }}" id="{{ loop.index }}">
         {% if result.geometry %}
           <!-- todo: separate out the result locations and template rendering
-          so that we aren't calling these from each result object directly. This feels kind of gross. -->
+          so that we aren't calling these from each result object directly. Ideally,
+          these geometries would be returned with an API. -->
           <script type="text/javascript">
             resultGeometries["{{ result.title }}"] = {{ result.geometry.geometry_collection | tojson | safe }};
           </script>
@@ -111,6 +112,7 @@
           {% endif %}
         
       </div>
+
       <!-- only show the buttons if javascript is enabled (nojs not defined) -->
       {% if nojs is not defined %}
         <button class="show_more_button">Show more</button>

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ volumes:
 services:
 
   gleaner-setup:
-    image: nsfearthcube/gleaner:dev-v3.0.5-development
+    image: nsfearthcube/gleaner:dev-v3.0.6-development
     command: -cfg gleaner -setup
     depends_on:
       - triplestore
@@ -54,7 +54,7 @@ services:
     - update@./geosparql.sparql
     - "http://triplestore:7200/repositories/polder/statements"
   gleaner:
-    image: nsfearthcube/gleaner:dev-v3.0.5-development
+    image: nsfearthcube/gleaner:dev-v3.0.6-development
     command: -cfg gleaner
     depends_on:
       - triplestore

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: nein09/polder-federated-search:1.43.4
+    image: nein09/polder-federated-search:1.43.5
     depends_on:
       - triplestore
       - s3system

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.43.4"
+appVersion: "1.43.5"

--- a/helm/templates/recreate-index.yaml
+++ b/helm/templates/recreate-index.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /context
             workingDir: /context
           - name: gleaner-index
-            image: nsfearthcube/gleaner:dev-v3.0.4-development
+            image: nsfearthcube/gleaner:dev-v3.0.6-development
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
             - -cfg

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -79,7 +79,7 @@ spec:
         - "{{- include "gleaner.triplestore.endpoint" . }}/repositories/{{ .Values.storageNamespace }}/statements"
       # Run gleaner setup, which creates cloud storage buckets
       - name: gleaner-setup
-        image: nsfearthcube/gleaner:dev-v3.0.5-development
+        image: nsfearthcube/gleaner:dev-v3.0.6-development
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -cfg
@@ -137,7 +137,7 @@ spec:
         workingDir: /context
       # Finally, index our data repositories!
       - name: gleaner-initial-index
-        image: nsfearthcube/gleaner:dev-v3.0.5-development
+        image: nsfearthcube/gleaner:dev-v3.0.6-development
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - -cfg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.43.4",
+  "version": "1.43.5",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
This change:
- tightens up mobile styles for small screens, including on the map
- Makes the map appear below the paginator when it is displayed for search results
- Prepares the map to be initialized for reasons other than displaying search results (maybe there will be two map areas in practice, one for people to draw on for spatial search and one to show results, not sure)
- Makes the loading spinner take up the whole page so it looks less like the page jumps around when searching / paging
- Changes the date search labels to hopefully make more sense
- Adds a description for screenreaders to the maps
