### PR TITLE
A step toward speeding up sparql queries

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
      - SERVICE_PORTS=9222
 
   webapp:
-    image: nein09/polder-federated-search:1.43.5
+    image: nein09/polder-federated-search:1.43.6
     depends_on:
       - triplestore
       - s3system

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.43.5"
+appVersion: "1.43.6"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -64,7 +64,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: '$http_origin'

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -64,6 +64,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: '$http_origin'

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -64,6 +64,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-origin: '$http_origin'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polder-federated-search",
   "license": "BSD-3-Clause",
-  "version": "1.43.5",
+  "version": "1.43.6",
   "description": "A federated search for the polar research community",
   "author": "Melinda Minch <melinda@melindaminch.com>",
   "repository": "https://github.com/nein09/polder-federated-search",


### PR DESCRIPTION
This can at least make what's on search-dev shippable to production.

What I found was two things:
- `?catalog ?relationship ?s . ` is by far the most expensive thing in that query - it takes the most time, by orders of magnitude, so I changed things around so that it is called fewer times.
- `FILTER( CONTAINS(?author, '''{author}''')) .` was taking a long time because `?author` is optional. Changing it to `FILTER(BOUND(?author) && CONTAINS(?author, '''{author}''')) .` to check whether `?author` even exists first helped.
Check whether ?author is bound and minimize calls for an expensive statement