### PR TITLE
Faceted indexing

### DIFF
--- a/docker/lucene-connector.sparql
+++ b/docker/lucene-connector.sparql
@@ -7,6 +7,7 @@ INSERT DATA {
       "fields": [
         {
           "fieldName": "fts",
+          "fieldNameTransform": "predicate.localName",
           "propertyChain": [
             "$literal"
           ],

--- a/helm/templates/crawl.yaml
+++ b/helm/templates/crawl.yaml
@@ -67,7 +67,7 @@ spec:
               mountPath: /config
           containers:
           - name: write-to-triplestore
-            image: bitnami/minio-client:2022
+            image: bitnami/minio-client:2022.9.16
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:

--- a/helm/templates/recreate-index.yaml
+++ b/helm/templates/recreate-index.yaml
@@ -26,7 +26,7 @@ spec:
               name: polder-repo-config
           initContainers:
           - name: remove-minio-files
-            image: bitnami/minio-client:2022
+            image: bitnami/minio-client:2022.9.16
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:
@@ -127,7 +127,7 @@ spec:
             - "{{- include "gleaner.triplestore.endpoint" . }}/repositories/{{ .Values.storageNamespace }}/statements"
           containers:
           - name: write-to-triplestore
-            image: bitnami/minio-client:2022
+            image: bitnami/minio-client:2022.9.16
             env:
             - name: MINIO_CLIENT_ACCESS_KEY
               valueFrom:

--- a/helm/templates/setup-gleaner.yaml
+++ b/helm/templates/setup-gleaner.yaml
@@ -162,7 +162,7 @@ spec:
           mountPath: /config
       containers:
       - name: write-to-triplestore
-        image: bitnami/minio-client:2022
+        image: bitnami/minio-client:2022.9.16
         env:
         - name: MINIO_CLIENT_ACCESS_KEY
           valueFrom:


### PR DESCRIPTION
- Enable faceted indexing / searching in Lucene connector config
- Revert to an earlier version of minio-client in Helm charts because it includes curl (we are using that)